### PR TITLE
Remove bad whitespace character

### DIFF
--- a/dist/ngMask.js
+++ b/dist/ngMask.js
@@ -8,7 +8,7 @@
       return {
         restrict: 'A',
         require: 'ngModel',
-        compile: function($element, $attrs) { 
+        compile: function($element, $attrs) {
          if (!$attrs.mask || !$attrs.ngModel) {
             $log.info('Mask and ng-model attributes are required!');
             return;


### PR DESCRIPTION
This was causing the following error: Â is not defined

See https://github.com/candreoliveira/ngMask/issues/99